### PR TITLE
feat: add additional fields property for custom data in Firecrawl API nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,9 @@ To use the Firecrawl node, you need to:
 
 ## Version history
 
+### 1.0.4
+- Add additional fields property for custom data in Firecrawl API nodes
+
 ### 1.0.2
 - Add integration parameter in all endpoint calls
 

--- a/nodes/Firecrawl/api/common.ts
+++ b/nodes/Firecrawl/api/common.ts
@@ -67,9 +67,6 @@ export function createUrlProperty(
 			},
 		},
 		displayOptions: {
-			hide: {
-				useCustomBody: [true],
-			},
 			show: {
 				resource: [resourceName],
 				operation: [operationName],

--- a/nodes/Firecrawl/api/crawl/index.ts
+++ b/nodes/Firecrawl/api/crawl/index.ts
@@ -1,4 +1,9 @@
-import { INodeProperties } from 'n8n-workflow';
+import {
+	INodeProperties,
+	IDataObject,
+	IExecuteSingleFunctions,
+	IHttpRequestOptions,
+} from 'n8n-workflow';
 import {
 	buildApiProperties,
 	createOperationNotice,
@@ -282,6 +287,74 @@ function createCrawlOptionsProperty(operationName: string): INodeProperties {
 }
 
 /**
+ * Create additional fields property for custom data
+ */
+function createAdditionalFieldsProperty(operation: string): INodeProperties {
+	return {
+		displayName: 'Additional Fields',
+		name: 'additionalFields',
+		type: 'collection',
+		placeholder: 'Add Field',
+		default: {},
+		description: 'Additional fields to send in the request body',
+		options: [
+			{
+				displayName: 'Custom Properties (JSON)',
+				name: 'customProperties',
+				type: 'json',
+				default: '{}',
+				description: 'Custom JSON properties to add to the request body',
+			},
+		],
+		routing: {
+			request: {
+				body: {
+					additionalFields: '={{ $value }}',
+				},
+			},
+			send: {
+				preSend: [
+					async function (
+						this: IExecuteSingleFunctions,
+						requestOptions: IHttpRequestOptions,
+					): Promise<IHttpRequestOptions> {
+						if (typeof requestOptions.body !== 'object' || !requestOptions.body) {
+							return requestOptions;
+						}
+
+						const body = requestOptions.body as IDataObject;
+						const additionalFields = body.additionalFields as IDataObject;
+
+						if (additionalFields) {
+							// Handle custom properties JSON
+							if (additionalFields.customProperties) {
+								try {
+									const customProps = JSON.parse(additionalFields.customProperties as string);
+									Object.assign(requestOptions.body as IDataObject, customProps);
+								} catch (error) {
+									// If JSON parsing fails, just skip
+								}
+							}
+
+							// Remove the additionalFields wrapper
+							delete body.additionalFields;
+						}
+
+						return requestOptions;
+					},
+				],
+			},
+		},
+		displayOptions: {
+			show: {
+				operation: [operation],
+				useCustomBody: [true],
+			},
+		},
+	};
+}
+
+/**
  * Create the properties for the crawl operation
  */
 function createCrawlProperties(): INodeProperties[] {
@@ -314,5 +387,8 @@ function createCrawlProperties(): INodeProperties[] {
 
 // Build and export the properties and options
 const { options, properties } = buildApiProperties(name, displayName, createCrawlProperties());
+
+// Add the additional fields property separately so it appears only when custom body is enabled
+properties.push(createAdditionalFieldsProperty(name));
 
 export { options, properties };

--- a/nodes/Firecrawl/api/extract/index.ts
+++ b/nodes/Firecrawl/api/extract/index.ts
@@ -1,4 +1,9 @@
-import { INodeProperties } from 'n8n-workflow';
+import {
+	INodeProperties,
+	IDataObject,
+	IExecuteSingleFunctions,
+	IHttpRequestOptions,
+} from 'n8n-workflow';
 import { buildApiProperties, createOperationNotice, createScrapeOptionsProperty } from '../common';
 
 const name = 'extract';
@@ -44,9 +49,6 @@ function createUrlsProperty(): INodeProperties {
 			},
 		},
 		displayOptions: {
-			hide: {
-				useCustomBody: [true],
-			},
 			show: {
 				resource: ['Default'],
 				operation: [operationName],
@@ -220,6 +222,74 @@ function createShowSourcesProperty(): INodeProperties {
 }
 
 /**
+ * Create additional fields property for custom data
+ */
+function createAdditionalFieldsProperty(operation: string): INodeProperties {
+	return {
+		displayName: 'Additional Fields',
+		name: 'additionalFields',
+		type: 'collection',
+		placeholder: 'Add Field',
+		default: {},
+		description: 'Additional fields to send in the request body',
+		options: [
+			{
+				displayName: 'Custom Properties (JSON)',
+				name: 'customProperties',
+				type: 'json',
+				default: '{}',
+				description: 'Custom JSON properties to add to the request body',
+			},
+		],
+		routing: {
+			request: {
+				body: {
+					additionalFields: '={{ $value }}',
+				},
+			},
+			send: {
+				preSend: [
+					async function (
+						this: IExecuteSingleFunctions,
+						requestOptions: IHttpRequestOptions,
+					): Promise<IHttpRequestOptions> {
+						if (typeof requestOptions.body !== 'object' || !requestOptions.body) {
+							return requestOptions;
+						}
+
+						const body = requestOptions.body as IDataObject;
+						const additionalFields = body.additionalFields as IDataObject;
+
+						if (additionalFields) {
+							// Handle custom properties JSON
+							if (additionalFields.customProperties) {
+								try {
+									const customProps = JSON.parse(additionalFields.customProperties as string);
+									Object.assign(requestOptions.body as IDataObject, customProps);
+								} catch (error) {
+									// If JSON parsing fails, just skip
+								}
+							}
+
+							// Remove the additionalFields wrapper
+							delete body.additionalFields;
+						}
+
+						return requestOptions;
+					},
+				],
+			},
+		},
+		displayOptions: {
+			show: {
+				operation: [operation],
+				useCustomBody: [true],
+			},
+		},
+	};
+}
+
+/**
  * Creates all properties for the extract operation
  * @returns Array of properties for the extract operation
  */
@@ -239,5 +309,8 @@ function createExtractProperties(): INodeProperties[] {
 
 // Build and export the properties and options
 const { options, properties } = buildApiProperties(name, displayName, createExtractProperties());
+
+// Add the additional fields property separately so it appears only when custom body is enabled
+properties.push(createAdditionalFieldsProperty(name));
 
 export { options, properties };

--- a/nodes/Firecrawl/api/getCrawlStatus/index.ts
+++ b/nodes/Firecrawl/api/getCrawlStatus/index.ts
@@ -26,9 +26,6 @@ function createCrawlIdProperty(): INodeProperties {
 			},
 		},
 		displayOptions: {
-			hide: {
-				useCustomBody: [true],
-			},
 			show: {
 				resource: ['Default'],
 				operation: [operationName],

--- a/nodes/Firecrawl/api/getExtractStatus/index.ts
+++ b/nodes/Firecrawl/api/getExtractStatus/index.ts
@@ -24,9 +24,6 @@ function createExtractIdProperty(): INodeProperties {
 			},
 		},
 		displayOptions: {
-			hide: {
-				useCustomBody: [true],
-			},
 			show: {
 				resource: ['Default'],
 				operation: [operationName],

--- a/nodes/Firecrawl/api/map/index.ts
+++ b/nodes/Firecrawl/api/map/index.ts
@@ -1,4 +1,9 @@
-import { INodeProperties } from 'n8n-workflow';
+import {
+	INodeProperties,
+	IDataObject,
+	IExecuteSingleFunctions,
+	IHttpRequestOptions,
+} from 'n8n-workflow';
 import { buildApiProperties, createOperationNotice, createUrlProperty } from '../common';
 
 // Define the operation name and display name
@@ -143,6 +148,74 @@ function createTimeoutProperty(): INodeProperties {
 }
 
 /**
+ * Create additional fields property for custom data
+ */
+function createAdditionalFieldsProperty(operation: string): INodeProperties {
+	return {
+		displayName: 'Additional Fields',
+		name: 'additionalFields',
+		type: 'collection',
+		placeholder: 'Add Field',
+		default: {},
+		description: 'Additional fields to send in the request body',
+		options: [
+			{
+				displayName: 'Custom Properties (JSON)',
+				name: 'customProperties',
+				type: 'json',
+				default: '{}',
+				description: 'Custom JSON properties to add to the request body',
+			},
+		],
+		routing: {
+			request: {
+				body: {
+					additionalFields: '={{ $value }}',
+				},
+			},
+			send: {
+				preSend: [
+					async function (
+						this: IExecuteSingleFunctions,
+						requestOptions: IHttpRequestOptions,
+					): Promise<IHttpRequestOptions> {
+						if (typeof requestOptions.body !== 'object' || !requestOptions.body) {
+							return requestOptions;
+						}
+
+						const body = requestOptions.body as IDataObject;
+						const additionalFields = body.additionalFields as IDataObject;
+
+						if (additionalFields) {
+							// Handle custom properties JSON
+							if (additionalFields.customProperties) {
+								try {
+									const customProps = JSON.parse(additionalFields.customProperties as string);
+									Object.assign(requestOptions.body as IDataObject, customProps);
+								} catch (error) {
+									// If JSON parsing fails, just skip
+								}
+							}
+
+							// Remove the additionalFields wrapper
+							delete body.additionalFields;
+						}
+
+						return requestOptions;
+					},
+				],
+			},
+		},
+		displayOptions: {
+			show: {
+				operation: [operation],
+				useCustomBody: [true],
+			},
+		},
+	};
+}
+
+/**
  * Create the properties for the map operation
  */
 function createMapProperties(): INodeProperties[] {
@@ -166,5 +239,8 @@ function createMapProperties(): INodeProperties[] {
 
 // Build and export the properties and options
 const { options, properties } = buildApiProperties(name, displayName, createMapProperties());
+
+// Add the additional fields property separately so it appears only when custom body is enabled
+properties.push(createAdditionalFieldsProperty(name));
 
 export { options, properties };

--- a/nodes/Firecrawl/api/scrape/index.ts
+++ b/nodes/Firecrawl/api/scrape/index.ts
@@ -1,4 +1,9 @@
-import { INodeProperties } from 'n8n-workflow';
+import {
+	INodeProperties,
+	IDataObject,
+	IExecuteSingleFunctions,
+	IHttpRequestOptions,
+} from 'n8n-workflow';
 import {
 	buildApiProperties,
 	createOperationNotice,
@@ -10,6 +15,74 @@ import {
 export const name = 'scrape';
 export const displayName = 'Scrape a url and get its content';
 export const operationName = 'scrape';
+
+/**
+ * Create additional fields property for custom data
+ */
+function createAdditionalFieldsProperty(operation: string): INodeProperties {
+	return {
+		displayName: 'Additional Fields',
+		name: 'additionalFields',
+		type: 'collection',
+		placeholder: 'Add Field',
+		default: {},
+		description: 'Additional fields to send in the request body',
+		options: [
+			{
+				displayName: 'Custom Properties (JSON)',
+				name: 'customProperties',
+				type: 'json',
+				default: '{}',
+				description: 'Custom JSON properties to add to the request body',
+			},
+		],
+		routing: {
+			request: {
+				body: {
+					additionalFields: '={{ $value }}',
+				},
+			},
+			send: {
+				preSend: [
+					async function (
+						this: IExecuteSingleFunctions,
+						requestOptions: IHttpRequestOptions,
+					): Promise<IHttpRequestOptions> {
+						if (typeof requestOptions.body !== 'object' || !requestOptions.body) {
+							return requestOptions;
+						}
+
+						const body = requestOptions.body as IDataObject;
+						const additionalFields = body.additionalFields as IDataObject;
+
+						if (additionalFields) {
+							// Handle custom properties JSON
+							if (additionalFields.customProperties) {
+								try {
+									const customProps = JSON.parse(additionalFields.customProperties as string);
+									Object.assign(requestOptions.body as IDataObject, customProps);
+								} catch (error) {
+									// If JSON parsing fails, just skip
+								}
+							}
+
+							// Remove the additionalFields wrapper
+							delete body.additionalFields;
+						}
+
+						return requestOptions;
+					},
+				],
+			},
+		},
+		displayOptions: {
+			show: {
+				operation: [operation],
+				useCustomBody: [true],
+			},
+		},
+	};
+}
 
 /**
  * Create the properties for the scrape operation
@@ -29,5 +102,8 @@ function createScrapeProperties(): INodeProperties[] {
 
 // Build and export the properties and options
 const { options, properties } = buildApiProperties(name, displayName, createScrapeProperties());
+
+// Add the additional fields property separately so it appears only when custom body is enabled
+properties.push(createAdditionalFieldsProperty(name));
 
 export { options, properties };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mendable/n8n-nodes-firecrawl",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Firecrawl node for n8n",
   "keywords": [
     "n8n-community-node-package"


### PR DESCRIPTION
- Introduced a new 'Additional Fields' property across various Firecrawl API operations to allow users to send custom

**Preview**

https://github.com/user-attachments/assets/f899fab1-4a9e-4c6c-8145-db997cf355ab


----

Closes #4
